### PR TITLE
feat: add i18n support and refactor translation utilities to OOP

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,8 +119,8 @@
       },
       {
         "command": "kubelingoassist.toggleSyncScroll",
-        "key": "ctrl+shift+s",
-        "mac": "cmd+shift+s",
+        "key": "ctrl+shift+z",
+        "mac": "cmd+shift+z",
         "when": "editorTextFocus || view == kubelingoassist-view"
       },
       {

--- a/src/features/i18n/i18n.ts
+++ b/src/features/i18n/i18n.ts
@@ -1,0 +1,148 @@
+import * as vscode from 'vscode';
+import { TranslationKeys, SupportedLanguage, TranslationResource } from './types';
+import { en } from './resources/en';
+import { ko } from './resources/ko';
+import { ja } from './resources/ja';
+
+/**
+ * 다국어 지원을 위한 국제화(i18n) 클래스입니다.
+ */
+export class I18n {
+    private static instance: I18n;
+    private currentLanguage: SupportedLanguage = 'en';
+    private resources: Record<SupportedLanguage, TranslationResource> = {
+        'en': en,
+        'ko': ko,
+        'ja': ja,
+        'zh-cn': en, // TODO: Add Chinese Simplified
+        'zh': en,    // TODO: Add Chinese Traditional
+        'fr': en,    // TODO: Add French
+        'de': en,    // TODO: Add German
+        'es': en,    // TODO: Add Spanish
+    };
+
+    private constructor() {
+        this.initializeLanguage();
+    }
+
+    /**
+     * I18n 클래스의 싱글톤 인스턴스를 반환합니다.
+     */
+    public static getInstance(): I18n {
+        if (!I18n.instance) {
+            I18n.instance = new I18n();
+        }
+        return I18n.instance;
+    }
+
+    /**
+     * VS Code 설정에서 언어를 초기화합니다.
+     */
+    private initializeLanguage(): void {
+        // VS Code의 언어 설정을 가져옵니다
+        const vsCodeLang = vscode.env.language;
+        
+        // 지원되는 언어인지 확인하고 설정
+        if (this.isSupportedLanguage(vsCodeLang)) {
+            this.currentLanguage = vsCodeLang;
+        } else {
+            // 언어 코드의 첫 부분만 확인 (예: 'ko-KR' -> 'ko')
+            const baseLang = vsCodeLang.split('-')[0];
+            if (this.isSupportedLanguage(baseLang)) {
+                this.currentLanguage = baseLang as SupportedLanguage;
+            }
+        }
+    }
+
+    /**
+     * 주어진 언어 코드가 지원되는지 확인합니다.
+     */
+    private isSupportedLanguage(lang: string): lang is SupportedLanguage {
+        return Object.keys(this.resources).includes(lang);
+    }
+
+    /**
+     * 현재 언어를 반환합니다.
+     */
+    public getCurrentLanguage(): SupportedLanguage {
+        return this.currentLanguage;
+    }
+
+    /**
+     * 언어를 변경합니다.
+     */
+    public setLanguage(language: SupportedLanguage): void {
+        this.currentLanguage = language;
+    }
+
+    /**
+     * 중첩된 객체에서 키를 사용해 값을 가져옵니다.
+     */
+    private getNestedValue(obj: any, path: string): string {
+        return path.split('.').reduce((current, key) => current?.[key], obj) || path;
+    }
+
+    /**
+     * 번역 키에 해당하는 번역된 문자열을 반환합니다.
+     * 
+     * @param key - 번역 키 (예: 'common.ok', 'messages.kubelingoDisabled')
+     * @param params - 템플릿 매개변수 (예: { filename: 'test.md' })
+     * @returns 번역된 문자열
+     */
+    public t(key: string, params?: Record<string, string>): string {
+        const resource = this.resources[this.currentLanguage];
+        let translation = this.getNestedValue(resource, key);
+        
+        // 번역을 찾을 수 없으면 영어를 fallback으로 사용
+        if (translation === key && this.currentLanguage !== 'en') {
+            translation = this.getNestedValue(this.resources.en, key);
+        }
+        
+        // 매개변수 치환
+        if (params) {
+            Object.entries(params).forEach(([param, value]) => {
+                translation = translation.replace(new RegExp(`\\{${param}\\}`, 'g'), value);
+            });
+        }
+        
+        return translation;
+    }
+
+    /**
+     * 메시지 표시 시 국제화된 텍스트를 사용합니다.
+     */
+    public showInformationMessage(key: string, params?: Record<string, string>, ...items: string[]): Thenable<string | undefined> {
+        return vscode.window.showInformationMessage(this.t(key, params), ...items);
+    }
+
+    /**
+     * 경고 메시지 표시 시 국제화된 텍스트를 사용합니다.
+     */
+    public showWarningMessage(key: string, params?: Record<string, string>, ...items: string[]): Thenable<string | undefined> {
+        return vscode.window.showWarningMessage(this.t(key, params), ...items);
+    }
+
+    /**
+     * 오류 메시지 표시 시 국제화된 텍스트를 사용합니다.
+     */
+    public showErrorMessage(key: string, params?: Record<string, string>, ...items: string[]): Thenable<string | undefined> {
+        return vscode.window.showErrorMessage(this.t(key, params), ...items);
+    }
+
+    /**
+     * Quick Pick 표시 시 국제화된 텍스트를 사용합니다.
+     */
+    public showQuickPick<T extends vscode.QuickPickItem>(
+        items: readonly T[] | Thenable<readonly T[]>,
+        options?: vscode.QuickPickOptions & { placeholderKey?: string; placeholderParams?: Record<string, string> }
+    ): Thenable<T | undefined> {
+        const quickPickOptions = { ...options };
+        if (options?.placeholderKey) {
+            quickPickOptions.placeHolder = this.t(options.placeholderKey, options.placeholderParams);
+        }
+        return vscode.window.showQuickPick(items, quickPickOptions);
+    }
+}
+
+// 전역 인스턴스 export
+export const i18n = I18n.getInstance();

--- a/src/features/i18n/index.ts
+++ b/src/features/i18n/index.ts
@@ -1,0 +1,5 @@
+export { I18n, i18n } from './i18n';
+export { SupportedLanguage, TranslationKeys, TranslationResource, LanguageInfo, LANGUAGE_NAMES, SUPPORTED_LANGUAGES, LANGUAGE_OPTIONS } from './types';
+export { en } from './resources/en';
+export { ko } from './resources/ko';
+export { ja } from './resources/ja';

--- a/src/features/i18n/resources/en.ts
+++ b/src/features/i18n/resources/en.ts
@@ -1,0 +1,71 @@
+import { TranslationResource } from '../types';
+
+export const en: TranslationResource = {
+  common: {
+    ok: 'OK',
+    cancel: 'Cancel',
+    create: 'Create',
+    overwrite: 'Overwrite',
+    loading: 'Loading...',
+    error: 'Error',
+    success: 'Success',
+  },
+
+  commands: {
+    openTranslationFile: 'Open Translation File',
+    openReviewFile: 'Open Review File',
+    toggleSyncScroll: 'Toggle Sync Scroll',
+    toggleKubelingo: 'Toggle KubelingoAssist',
+    changeMode: 'Change Mode',
+    configureAI: 'Configure AI',
+    showAPIKeyStatus: 'Show API Key Status',
+    translateSelected: 'Translate Selected Text',
+  },
+
+  messages: {
+    kubelingoDisabled: 'KubelingoAssist is disabled. Please enable it first.',
+    enableKubelingoFirst: 'Please enable KubelingoAssist first.',
+    noActiveFile: 'No active file found.',
+    invalidFilePath: 'File path is not valid.',
+    cannotFindTranslationPath: 'Cannot find translation file path. This extension works with Kubernetes documentation repository\'s /content/en/ or /content/{language}/ structure.',
+    splitViewOpened: 'Files opened in split view. Use Cmd+Shift+Z to enable scroll synchronization.',
+    syncScrollEnabled: 'Synchronized scrolling enabled.',
+    syncScrollDisabled: 'Synchronized scrolling disabled.',
+    kubelingoEnabled: 'KubelingoAssist enabled.',
+    kubelingoDisabledMsg: 'KubelingoAssist disabled.',
+    reviewModeEnabled: 'Review mode enabled. You can now see changed files from recent commits.',
+    translationModeEnabled: 'Translation mode enabled.',
+    translationFileNotExists: 'Translation file does not exist. Would you like to create a new one?',
+    createNewFile: 'Create new file?',
+    fileAlreadyExists: 'Translation file already exists: {filename}\nWould you like to overwrite it?',
+    fileCopied: 'File copied successfully. Start translating!',
+    fileCopyFailed: 'File copy failed: {error}',
+    originalFileNotFound: 'Original file not found: {path}',
+    gitUtilitiesNotAvailable: 'Git utilities not available',
+    noRecentCommits: 'No recent commits found',
+    noTranslationFilesFound: 'No translation files found in recent commits. This extension works with Kubernetes documentation repositories that have content/{language} structure. Make sure you have committed some translated markdown files in the expected directory structure.',
+    openedForReview: 'Opened {path} with original English file for review',
+    failedToOpenReviewMode: 'Failed to open file in review mode: {error}',
+    failedToGetRecentCommits: 'Failed to get recent commits: {error}',
+    couldNotDetermineOriginalPath: 'Could not determine original English file path',
+    notKubernetesRepo: 'This extension only works with the Kubernetes documentation repository (kubernetes/website). Please open the kubernetes/website repository to use translation features.',
+    kubernetesRepoOnly: 'This extension only works with the Kubernetes documentation repository (kubernetes/website). Please open the kubernetes/website repository to use review mode.',
+  },
+
+  ui: {
+    selectTargetLanguage: 'Select target language for translation',
+    selectFileToReview: 'Select a translation file to review',
+    fileStatus: {
+      modified: 'Modified',
+      added: 'Added',
+      other: 'Other',
+    },
+    fromCommit: 'From commit: {message}',
+  },
+
+  paths: {
+    contentDirectory: '/content/',
+    englishContent: '/content/en/',
+    translationContent: '/content/{language}/',
+  },
+};

--- a/src/features/i18n/resources/ja.ts
+++ b/src/features/i18n/resources/ja.ts
@@ -1,0 +1,71 @@
+import { TranslationResource } from '../types';
+
+export const ja: TranslationResource = {
+  common: {
+    ok: 'OK',
+    cancel: 'キャンセル',
+    create: '作成',
+    overwrite: '上書き',
+    loading: '読み込み中...',
+    error: 'エラー',
+    success: '成功',
+  },
+
+  commands: {
+    openTranslationFile: '翻訳ファイルを開く',
+    openReviewFile: 'レビューファイルを開く',
+    toggleSyncScroll: 'スクロール同期の切り替え',
+    toggleKubelingo: 'KubelingoAssistの切り替え',
+    changeMode: 'モード変更',
+    configureAI: 'AI設定の構成',
+    showAPIKeyStatus: 'APIキーステータスの確認',
+    translateSelected: '選択したテキストを翻訳',
+  },
+
+  messages: {
+    kubelingoDisabled: 'KubelingoAssistが無効になっています。まず有効にしてください。',
+    enableKubelingoFirst: 'まずKubelingoAssistを有効にしてください。',
+    noActiveFile: 'アクティブなファイルがありません。',
+    invalidFilePath: 'ファイルパスが無効です。',
+    cannotFindTranslationPath: '翻訳ファイルのパスが見つかりません。この拡張機能はKubernetesドキュメントリポジトリの/content/en/または/content/{言語}/構造で動作します。',
+    splitViewOpened: 'ファイルを分割表示で開きました。Cmd+Shift+Zでスクロール同期を有効にしてください。',
+    syncScrollEnabled: '同期スクロールが有効になりました。',
+    syncScrollDisabled: '同期スクロールが無効になりました。',
+    kubelingoEnabled: 'KubelingoAssistが有効になりました。',
+    kubelingoDisabledMsg: 'KubelingoAssistが無効になりました。',
+    reviewModeEnabled: 'レビューモードが有効になりました。最近のコミットから変更されたファイルを確認できます。',
+    translationModeEnabled: '翻訳モードが有効になりました。',
+    translationFileNotExists: '翻訳ファイルが存在しません。新しく作成しますか？',
+    createNewFile: '新しいファイルを作成しますか？',
+    fileAlreadyExists: '翻訳ファイルがすでに存在します：{filename}\n上書きしますか？',
+    fileCopied: 'ファイルをコピーしました。翻訳を開始してください！',
+    fileCopyFailed: 'ファイルのコピーに失敗しました：{error}',
+    originalFileNotFound: '元のファイルが見つかりません：{path}',
+    gitUtilitiesNotAvailable: 'Gitユーティリティが利用できません',
+    noRecentCommits: '最近のコミットが見つかりません',
+    noTranslationFilesFound: '最近のコミットで翻訳ファイルが見つかりません。この拡張機能はcontent/{言語}構造を持つKubernetesドキュメントリポジトリで動作します。予想されるディレクトリ構造に翻訳されたMarkdownファイルをコミットしたことを確認してください。',
+    openedForReview: 'レビューのために元の英語ファイルと一緒に{path}を開きました',
+    failedToOpenReviewMode: 'レビューモードでファイルを開くのに失敗しました：{error}',
+    failedToGetRecentCommits: '最近のコミットの取得に失敗しました：{error}',
+    couldNotDetermineOriginalPath: '元の英語ファイルパスを特定できません',
+    notKubernetesRepo: 'この拡張機能はKubernetesドキュメントリポジトリ（kubernetes/website）でのみ動作します。翻訳機能を使用するにはkubernetes/websiteリポジトリを開いてください。',
+    kubernetesRepoOnly: 'この拡張機能はKubernetesドキュメントリポジトリ（kubernetes/website）でのみ動作します。レビューモードを使用するにはkubernetes/websiteリポジトリを開いてください。',
+  },
+
+  ui: {
+    selectTargetLanguage: '翻訳対象の言語を選択してください',
+    selectFileToReview: 'レビューする翻訳ファイルを選択してください',
+    fileStatus: {
+      modified: '変更済み',
+      added: '追加',
+      other: 'その他',
+    },
+    fromCommit: 'コミットから：{message}',
+  },
+
+  paths: {
+    contentDirectory: '/content/',
+    englishContent: '/content/en/',
+    translationContent: '/content/{言語}/',
+  },
+};

--- a/src/features/i18n/resources/ko.ts
+++ b/src/features/i18n/resources/ko.ts
@@ -1,0 +1,71 @@
+import { TranslationResource } from '../types';
+
+export const ko: TranslationResource = {
+  common: {
+    ok: '확인',
+    cancel: '취소',
+    create: '생성',
+    overwrite: '덮어쓰기',
+    loading: '로딩 중...',
+    error: '오류',
+    success: '성공',
+  },
+
+  commands: {
+    openTranslationFile: '번역 파일 열기',
+    openReviewFile: '리뷰 파일 열기',
+    toggleSyncScroll: '스크롤 동기화 토글',
+    toggleKubelingo: 'KubelingoAssist 토글',
+    changeMode: '모드 변경',
+    configureAI: 'AI 설정 구성',
+    showAPIKeyStatus: 'API 키 상태 확인',
+    translateSelected: '선택한 텍스트 번역',
+  },
+
+  messages: {
+    kubelingoDisabled: 'KubelingoAssist가 비활성화되었습니다. 먼저 활성화해주세요.',
+    enableKubelingoFirst: 'KubelingoAssist를 먼저 활성화해주세요.',
+    noActiveFile: '활성화된 파일이 없습니다.',
+    invalidFilePath: '파일 경로가 유효하지 않습니다.',
+    cannotFindTranslationPath: '번역 파일 경로를 찾을 수 없습니다. 이 확장 프로그램은 Kubernetes 문서 저장소의 /content/en/ 또는 /content/{언어}/ 구조에서 작동합니다.',
+    splitViewOpened: 'Split view로 파일을 열었습니다. Cmd+Shift+Z로 스크롤 동기화를 활성화하세요.',
+    syncScrollEnabled: '동기화 스크롤이 활성화되었습니다.',
+    syncScrollDisabled: '동기화 스크롤이 비활성화되었습니다.',
+    kubelingoEnabled: 'KubelingoAssist가 활성화되었습니다.',
+    kubelingoDisabledMsg: 'KubelingoAssist가 비활성화되었습니다.',
+    reviewModeEnabled: '리뷰 모드가 활성화되었습니다. 이제 최근 커밋의 변경된 파일을 볼 수 있습니다.',
+    translationModeEnabled: '번역 모드가 활성화되었습니다.',
+    translationFileNotExists: '번역 파일이 존재하지 않습니다. 새로 생성하시겠습니까?',
+    createNewFile: '새 파일을 생성하시겠습니까?',
+    fileAlreadyExists: '번역 파일이 이미 존재합니다: {filename}\n덮어쓰시겠습니까?',
+    fileCopied: '파일을 복사했습니다. 번역을 시작하세요!',
+    fileCopyFailed: '파일 복사 실패: {error}',
+    originalFileNotFound: '원본 파일이 존재하지 않습니다: {path}',
+    gitUtilitiesNotAvailable: 'Git 유틸리티를 사용할 수 없습니다',
+    noRecentCommits: '최근 커밋을 찾을 수 없습니다',
+    noTranslationFilesFound: '최근 커밋에서 번역 파일을 찾을 수 없습니다. 이 확장 프로그램은 content/{언어} 구조를 가진 Kubernetes 문서 저장소에서 작동합니다. 예상된 디렉터리 구조에 번역된 마크다운 파일을 커밋했는지 확인하세요.',
+    openedForReview: '리뷰를 위해 원본 영어 파일과 함께 {path}를 열었습니다',
+    failedToOpenReviewMode: '리뷰 모드로 파일을 여는데 실패했습니다: {error}',
+    failedToGetRecentCommits: '최근 커밋을 가져오는데 실패했습니다: {error}',
+    couldNotDetermineOriginalPath: '원본 영어 파일 경로를 확인할 수 없습니다',
+    notKubernetesRepo: '이 확장 프로그램은 Kubernetes 문서 저장소(kubernetes/website)에서만 작동합니다. 번역 기능을 사용하려면 kubernetes/website 저장소를 열어주세요.',
+    kubernetesRepoOnly: '이 확장 프로그램은 Kubernetes 문서 저장소(kubernetes/website)에서만 작동합니다. 리뷰 모드를 사용하려면 kubernetes/website 저장소를 열어주세요.',
+  },
+
+  ui: {
+    selectTargetLanguage: '번역할 대상 언어를 선택하세요',
+    selectFileToReview: '리뷰할 번역 파일을 선택하세요',
+    fileStatus: {
+      modified: '수정됨',
+      added: '추가됨',
+      other: '기타',
+    },
+    fromCommit: '커밋에서: {message}',
+  },
+
+  paths: {
+    contentDirectory: '/content/',
+    englishContent: '/content/en/',
+    translationContent: '/content/{언어}/',
+  },
+};

--- a/src/features/i18n/types.ts
+++ b/src/features/i18n/types.ts
@@ -1,0 +1,144 @@
+/**
+ * 지원되는 언어 코드를 나타내는 타입입니다.
+ */
+export type SupportedLanguage = 'en' | 'ko' | 'ja' | 'zh-cn' | 'zh' | 'fr' | 'de' | 'es';
+
+/**
+ * 번역 키 구조를 정의하는 인터페이스입니다.
+ */
+export interface TranslationKeys {
+  // Common messages
+  common: {
+    ok: string;
+    cancel: string;
+    create: string;
+    overwrite: string;
+    loading: string;
+    error: string;
+    success: string;
+  };
+
+  // Commands and actions
+  commands: {
+    openTranslationFile: string;
+    openReviewFile: string;
+    toggleSyncScroll: string;
+    toggleKubelingo: string;
+    changeMode: string;
+    configureAI: string;
+    showAPIKeyStatus: string;
+    translateSelected: string;
+  };
+
+  // Messages
+  messages: {
+    kubelingoDisabled: string;
+    enableKubelingoFirst: string;
+    noActiveFile: string;
+    cannotFindTranslationPath: string;
+    splitViewOpened: string;
+    syncScrollEnabled: string;
+    syncScrollDisabled: string;
+    kubelingoEnabled: string;
+    kubelingoDisabledMsg: string;
+    reviewModeEnabled: string;
+    translationModeEnabled: string;
+    translationFileNotExists: string;
+    createNewFile: string;
+    fileAlreadyExists: string;
+    fileCopied: string;
+    fileCopyFailed: string;
+    originalFileNotFound: string;
+    gitUtilitiesNotAvailable: string;
+    noRecentCommits: string;
+    noTranslationFilesFound: string;
+    openedForReview: string;
+    failedToOpenReviewMode: string;
+    notKubernetesRepo: string;
+    kubernetesRepoOnly: string;
+  };
+
+  // UI Labels
+  ui: {
+    selectTargetLanguage: string;
+    selectFileToReview: string;
+    fileStatus: {
+      modified: string;
+      added: string;
+      other: string;
+    };
+    fromCommit: string;
+  };
+
+  // File paths and extensions
+  paths: {
+    contentDirectory: string;
+    englishContent: string;
+    translationContent: string;
+  };
+}
+
+/**
+ * 언어별 번역 리소스를 나타내는 타입입니다.
+ */
+export type TranslationResource = TranslationKeys;
+
+/**
+ * 언어 정보를 나타내는 인터페이스입니다.
+ */
+export interface LanguageInfo {
+    label: string;
+    value: string;
+}
+
+/**
+ * 지원되는 언어 코드와 언어명 매핑입니다.
+ */
+
+
+/**
+ * 지원되는 언어 코드 배열입니다.
+ */
+export const SUPPORTED_LANGUAGES: SupportedLanguage[] = ['ko', 'ja', 'zh-cn', 'zh', 'fr', 'de', 'es'];
+
+/**
+ * 언어 선택을 위한 옵션 배열입니다.
+ */
+
+
+export const LANGUAGE_NAMES: { [key: string]: string } = {
+        'en': 'English',
+        'ko': '한국어',
+        'ja': '日本語',
+        'zh-cn': '中文(简体)',
+        'zh': '中文(繁体)',
+        'fr': 'Français',
+        'de': 'Deutsch',
+        'es': 'Español',
+        'it': 'Italiano',
+        'pt-br': 'Português',
+        'ru': 'Русский',
+        'uk': 'Українська',
+        'pl': 'Polski',
+        'hi': 'हिन्दी',
+        'vi': 'Việt Nam',
+        'id': 'Indonesia'
+    };
+
+export const LANGUAGE_OPTIONS: LanguageInfo[] = [
+        { label: '한국어 (ko)', value: 'ko' },
+        { label: '日本語 (ja)', value: 'ja' },
+        { label: '中文 (zh-cn)', value: 'zh-cn' },
+        { label: '中文 (zh)', value: 'zh' },
+        { label: 'Français (fr)', value: 'fr' },
+        { label: 'Deutsch (de)', value: 'de' },
+        { label: 'Español (es)', value: 'es' },
+        { label: 'Italiano (it)', value: 'it' },
+        { label: 'Português (pt-br)', value: 'pt-br' },
+        { label: 'Русский (ru)', value: 'ru' },
+        { label: 'Українська (uk)', value: 'uk' },
+        { label: 'Polski (pl)', value: 'pl' },
+        { label: 'हिन्दी (hi)', value: 'hi' },
+        { label: 'Việt Nam (vi)', value: 'vi' },
+        { label: 'Indonesia (id)', value: 'id' }
+    ];

--- a/src/features/translation/translation-utils.ts
+++ b/src/features/translation/translation-utils.ts
@@ -1,317 +1,11 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { i18n, LANGUAGE_NAMES, SUPPORTED_LANGUAGES, LANGUAGE_OPTIONS, LanguageInfo } from '../i18n';
 
 /**
- * 주어진 파일 경로에서 번역 파일의 경로를 생성합니다.
- * 영어 파일의 경우 대상 언어의 번역 파일 경로를 반환하고,
- * 번역 파일의 경우 원본 영어 파일 경로를 반환합니다.
- * 모든 쿠버네티스 컨텐츠 유형(docs, blog, case-studies 등)을 지원합니다.
- * 
- * @param filePath - 변환할 파일의 절대 경로
- * @returns 번역 파일 경로 또는 null (변환할 수 없는 경우)
- * 
- * @example
- * ```typescript
- * // 영어 파일에서 한국어 번역 파일로
- * await getTranslationPath('/content/en/docs/concepts/overview.md')
- * // Returns: '/content/ko/docs/concepts/overview.md'
- * 
- * await getTranslationPath('/content/en/blog/2024/news.md')
- * // Returns: '/content/ko/blog/2024/news.md'
- * 
- * // 번역 파일에서 영어 원본 파일로
- * getTranslationPath('/content/ko/case-studies/example.md')
- * // Returns: '/content/en/case-studies/example.md'
- * ```
+ * 번역 진행률 정보를 나타내는 인터페이스입니다.
  */
-export async function getTranslationPath(filePath: string): Promise<string | null> {
-    if (!filePath || typeof filePath !== 'string') {
-        console.warn('getTranslationPath: Invalid file path provided');
-        return null;
-    }
-
-    const normalizedPath = filePath.replace(/\\\\/g, '/');
-    
-    // 쿠버네티스 컨텐츠 경로인지 확인
-    if (!normalizedPath.includes('/content/')) {
-        console.warn('getTranslationPath: Path does not contain /content/ directory');
-        return null;
-    }
-    
-    // 영어 파일에서 번역 파일로
-    if (normalizedPath.includes('/content/en/')) {
-        const targetLanguage = await selectTargetLanguage();
-        if (!targetLanguage) {
-            console.log('getTranslationPath: User cancelled language selection');
-            return null;
-        }
-        
-        return normalizedPath.replace('/content/en/', `/content/${targetLanguage}/`);
-    }
-    
-    // 번역 파일에서 영어 파일로
-    const langMatch = normalizedPath.match(/\/content\/([^/]+)\//); 
-    if (langMatch && langMatch[1] !== 'en') {
-        // 지원되는 언어 코드인지 확인
-        const supportedLanguages = ['ko', 'ja', 'zh-cn', 'zh', 'fr', 'de', 'es', 'it', 'pt-br', 'ru', 'uk', 'pl', 'hi', 'vi', 'id'];
-        const detectedLang = langMatch[1];
-        
-        if (!supportedLanguages.includes(detectedLang)) {
-            console.warn(`getTranslationPath: Unsupported language code: ${detectedLang}`);
-            return null;
-        }
-        
-        return normalizedPath.replace(`/content/${detectedLang}/`, '/content/en/');
-    }
-    
-    console.warn('getTranslationPath: Path does not match expected content structure');
-    return null;
-}
-
-/**
- * 사용자에게 번역 대상 언어를 선택하도록 하는 VS Code Quick Pick을 표시합니다.
- * 쿠버네티스 공식 문서에서 지원하는 언어 목록을 제공합니다.
- * 
- * @returns 선택된 언어 코드 (예: 'ko', 'ja') 또는 null (취소된 경우)
- * 
- * @example
- * ```typescript
- * const language = await selectTargetLanguage();
- * if (language === 'ko') {
- *   console.log('한국어가 선택되었습니다');
- * }
- * ```
- */
-export async function selectTargetLanguage(): Promise<string | null> {
-    // 쿠버네티스에서 지원하는 언어 목록
-    const languages = [
-        { label: '한국어 (ko)', value: 'ko' },
-        { label: '日本語 (ja)', value: 'ja' },
-        { label: '中文 (zh-cn)', value: 'zh-cn' },
-        { label: '中文 (zh)', value: 'zh' },
-        { label: 'Français (fr)', value: 'fr' },
-        { label: 'Deutsch (de)', value: 'de' },
-        { label: 'Español (es)', value: 'es' },
-        { label: 'Italiano (it)', value: 'it' },
-        { label: 'Português (pt-br)', value: 'pt-br' },
-        { label: 'Русский (ru)', value: 'ru' },
-        { label: 'Українська (uk)', value: 'uk' },
-        { label: 'Polski (pl)', value: 'pl' },
-        { label: 'हिन्दी (hi)', value: 'hi' },
-        { label: 'Việt Nam (vi)', value: 'vi' },
-        { label: 'Indonesia (id)', value: 'id' }
-    ];
-    
-    const selected = await vscode.window.showQuickPick(languages, {
-        placeHolder: '번역할 대상 언어를 선택하세요',
-        matchOnDescription: true
-    });
-    
-    return selected?.value || null;
-}
-
-/**
- * 원본 파일과 번역 파일을 Split View로 엽니다.
- * 원본 파일은 왼쪽(ViewColumn.One), 번역 파일은 오른쪽(ViewColumn.Two)에 표시됩니다.
- * 번역 파일이 존재하지 않는 경우 생성할지 사용자에게 확인합니다.
- * 
- * @param originalPath - 원본 파일의 절대 경로
- * @param translationPath - 번역 파일의 절대 경로
- * 
- * @throws VS Code API 호출 중 오류가 발생한 경우
- * 
- * @example
- * ```typescript
- * await openSplitView(
- *   '/workspace/content/en/docs/concepts/overview.md',
- *   '/workspace/content/ko/docs/concepts/overview.md'
- * );
- * ```
- */
-export async function openSplitView(originalPath: string, translationPath: string) {
-    try {
-        // 원본 파일을 왼쪽에 열기
-        const originalUri = vscode.Uri.file(originalPath);
-        await vscode.commands.executeCommand('vscode.open', originalUri, { viewColumn: vscode.ViewColumn.One });
-        
-        // 번역 파일을 오른쪽에 열기
-        const translationUri = vscode.Uri.file(translationPath);
-        await vscode.commands.executeCommand('vscode.open', translationUri, { viewColumn: vscode.ViewColumn.Two });
-        
-        vscode.window.showInformationMessage('Split view로 파일을 열었습니다. Cmd+Shift+S로 스크롤 동기화를 활성화하세요.');
-        
-    } catch (error) {
-        // 번역 파일이 없으면 생성할지 물어보기
-        const createFile = await vscode.window.showWarningMessage(
-            '번역 파일이 존재하지 않습니다. 새로 생성하시겠습니까?',
-            '생성',
-            '취소'
-        );
-        
-        if (createFile === '생성') {
-            await createTranslationFile(originalPath, translationPath);
-        }
-    }
-}
-
-/**
- * 원본 파일을 복사하여 새로운 번역 파일을 생성합니다.
- * 필요한 디렉토리 구조를 자동으로 생성하고, 원본 내용을 그대로 복사합니다.
- * 생성 완료 후 자동으로 Split View를 엽니다.
- * 
- * @param originalPath - 복사할 원본 파일의 절대 경로
- * @param translationPath - 생성할 번역 파일의 절대 경로
- * 
- * @throws 파일 시스템 작업 중 오류가 발생한 경우 (권한 부족, 디스크 공간 부족 등)
- * 
- * @example
- * ```typescript
- * await createTranslationFile(
- *   '/workspace/content/en/blog/announcement.md',
- *   '/workspace/content/ko/blog/announcement.md'
- * );
- * ```
- */
-export async function createTranslationFile(originalPath: string, translationPath: string) {
-    if (!originalPath || !translationPath) {
-        vscode.window.showErrorMessage('파일 경로가 유효하지 않습니다.');
-        return;
-    }
-
-    try {
-        // 원본 파일 존재 여부 확인
-        const originalExists = await vscode.workspace.fs.stat(vscode.Uri.file(originalPath))
-            .then(() => true, () => false);
-            
-        if (!originalExists) {
-            vscode.window.showErrorMessage(`원본 파일이 존재하지 않습니다: ${originalPath}`);
-            return;
-        }
-        
-        // 번역 파일이 이미 존재하는지 확인
-        const translationExists = await vscode.workspace.fs.stat(vscode.Uri.file(translationPath))
-            .then(() => true, () => false);
-            
-        if (translationExists) {
-            const overwrite = await vscode.window.showWarningMessage(
-                `번역 파일이 이미 존재합니다: ${path.basename(translationPath)}\n덕어쓰시겠습니까?`,
-                '덤어쓰기',
-                '취소'
-            );
-            
-            if (overwrite !== '덤어쓰기') {
-                return;
-            }
-        }
-        
-        // 디렉토리 생성 (재귀적으로)
-        const dir = path.dirname(translationPath);
-        await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
-        
-        // 빈 번역 파일 생성
-        await vscode.workspace.fs.writeFile(
-            vscode.Uri.file(translationPath),
-            Buffer.from('', 'utf8')
-        );
-
-        vscode.window.showInformationMessage(`파일을 복사했습니다. 번역을 시작하세요!`);
-
-        // Split view로 열기
-        await openSplitView(originalPath, translationPath);
-        
-    } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        console.error('createTranslationFile error:', error);
-        vscode.window.showErrorMessage(`파일 복사 실패: ${errorMessage}`);
-    }
-}
-
-/**
- * 파일 경로에서 언어 코드를 추출하여 해당하는 언어명을 반환합니다.
- * 쿠버네티스 문서의 표준 경로 구조 (/content/{language}/)를 기준으로 합니다.
- * 
- * @param filePath - 언어를 추출할 파일의 절대 경로
- * @returns 언어명 (한국어, English 등) 또는 'Unknown' (인식할 수 없는 경우)
- * 
- * @example
- * ```typescript
- * extractLanguage('/content/ko/docs/concepts/overview.md')
- * // Returns: '한국어'
- * 
- * extractLanguage('/content/en/blog/post.md')
- * // Returns: 'English'
- * ```
- */
-export function extractLanguage(filePath: string): string {
-    const langMatch = filePath.match(/\/content\/([^/]+)\//); 
-    if (langMatch) {
-        const langCode = langMatch[1];
-        const languageNames: { [key: string]: string } = {
-            'en': 'English',
-            'ko': '한국어',
-            'ja': '日本語',
-            'zh-cn': '中文(简体)',
-            'zh': '中文(繁体)',
-            'fr': 'Français',
-            'de': 'Deutsch',
-            'es': 'Español',
-            'it': 'Italiano',
-            'pt-br': 'Português',
-            'ru': 'Русский',
-            'uk': 'Українська',
-            'pl': 'Polski',
-            'hi': 'हिन्दी',
-            'vi': 'Việt Nam',
-            'id': 'Indonesia'
-        };
-        return languageNames[langCode] || langCode.toUpperCase();
-    }
-    return 'Unknown';
-}
-
-/**
- * 파일 경로에서 언어 코드만을 추출합니다.
- * 쿠버네티스 문서의 표준 경로 구조 (/content/{language}/)를 기준으로 합니다.
- * 
- * @param filePath - 언어 코드를 추출할 파일의 절대 경로
- * @returns 언어 코드 (ko, en, ja 등) 또는 'unknown' (인식할 수 없는 경우)
- * 
- * @example
- * ```typescript
- * extractLanguageCode('/content/ko/docs/concepts/overview.md')
- * // Returns: 'ko'
- * 
- * extractLanguageCode('/content/zh-cn/blog/post.md')
- * // Returns: 'zh-cn'
- * ```
- */
-export function extractLanguageCode(filePath: string): string {
-    const langMatch = filePath.match(/\/content\/([^/]+)\//); 
-    return langMatch ? langMatch[1] : 'unknown';
-}
-
-/**
- * 원본 파일과 번역 파일의 라인 수를 비교하여 번역 진행률을 계산합니다.
- * 파일이 존재하지 않거나 읽기에 실패한 경우 null을 반환합니다.
- * 
- * @param originalPath - 원본 파일의 절대 경로
- * @param translationPath - 번역 파일의 절대 경로
- * @returns 라인 수 비교 결과 객체 또는 null (파일이 없거나 오류 발생시)
- * 
- * @example
- * ```typescript
- * const result = await compareLineCounts(
- *   '/content/en/docs/concepts/overview.md',
- *   '/content/ko/docs/concepts/overview.md'
- * );
- * 
- * if (result) {
- *   console.log(`번역 진행률: ${result.percentage}%`);
- *   console.log(`원본: ${result.originalLines}줄, 번역: ${result.translationLines}줄`);
- * }
- * ```
- */
-export async function compareLineCounts(originalPath: string, translationPath: string): Promise<{
+export interface TranslationProgress {
     /** 원본 파일의 총 라인 수 */
     originalLines: number;
     /** 번역 파일의 총 라인 수 */
@@ -320,32 +14,344 @@ export async function compareLineCounts(originalPath: string, translationPath: s
     isEqual: boolean;
     /** 번역 진행률 (번역 라인 수 / 원본 라인 수 * 100, 반올림) */
     percentage: number;
-} | null> {
-    try {
-        // 파일이 존재하는지 확인
-        const originalExists = await vscode.workspace.fs.stat(vscode.Uri.file(originalPath)).then(() => true, () => false);
-        const translationExists = await vscode.workspace.fs.stat(vscode.Uri.file(translationPath)).then(() => true, () => false);
-        
-        if (!originalExists || !translationExists) {
+}
+
+/**
+ * 쿠버네티스 문서 번역을 위한 유틸리티 클래스입니다.
+ * 파일 경로 변환, Split View 관리, 언어 처리 등의 기능을 제공합니다.
+ */
+export class TranslationUtils {
+
+    /**
+     * 주어진 파일 경로에서 번역 파일의 경로를 생성합니다.
+     * 영어 파일의 경우 대상 언어의 번역 파일 경로를 반환하고,
+     * 번역 파일의 경우 원본 영어 파일 경로를 반환합니다.
+     * 
+     * @param filePath - 변환할 파일의 절대 경로
+     * @returns 번역 파일 경로 또는 null (변환할 수 없는 경우)
+     */
+    async getTranslationPath(filePath: string): Promise<string | null> {
+        if (!this.validateFilePath(filePath)) {
             return null;
         }
 
-        // 파일 내용 읽기
+        const normalizedPath = this.normalizePath(filePath);
+        
+        if (!this.isKubernetesContentPath(normalizedPath)) {
+            console.warn('getTranslationPath: Path does not contain /content/ directory');
+            return null;
+        }
+        
+        if (this.isEnglishFile(normalizedPath)) {
+            return await this.getTranslationPathFromEnglish(normalizedPath);
+        }
+        
+        return this.getEnglishPathFromTranslation(normalizedPath);
+    }
+
+    /**
+     * 사용자에게 번역 대상 언어를 선택하도록 하는 VS Code Quick Pick을 표시합니다.
+     * 
+     * @returns 선택된 언어 코드 또는 null (취소된 경우)
+     */
+    async selectTargetLanguage(): Promise<string | null> {
+        const selected = await i18n.showQuickPick(LANGUAGE_OPTIONS, {
+            placeholderKey: 'ui.selectTargetLanguage',
+            matchOnDescription: true
+        });
+        
+        return selected?.value || null;
+    }
+
+    /**
+     * 원본 파일과 번역 파일을 Split View로 엽니다.
+     * 
+     * @param originalPath - 원본 파일의 절대 경로
+     * @param translationPath - 번역 파일의 절대 경로
+     */
+    async openSplitView(originalPath: string, translationPath: string): Promise<void> {
+        try {
+            await this.openFilesInSplitView(originalPath, translationPath);
+            this.scrollEditorsToTop();
+            this.showSplitViewMessage();
+        } catch (error) {
+            await this.handleSplitViewError(originalPath, translationPath);
+        }
+    }
+
+    /**
+     * 원본 파일을 복사하여 새로운 번역 파일을 생성합니다.
+     * 
+     * @param originalPath - 복사할 원본 파일의 절대 경로
+     * @param translationPath - 생성할 번역 파일의 절대 경로
+     */
+    async createTranslationFile(originalPath: string, translationPath: string): Promise<void> {
+        if (!this.validateCreateFileParams(originalPath, translationPath)) {
+            return;
+        }
+
+        try {
+            const canProceed = await this.checkFileCreationPreconditions(originalPath, translationPath);
+            if (!canProceed) {
+                return;
+            }
+
+            await this.createFileAndDirectory(translationPath);
+            await this.openSplitView(originalPath, translationPath);
+            
+            i18n.showInformationMessage('messages.fileCopied');
+        } catch (error) {
+            this.handleFileCreationError(error);
+        }
+    }
+
+    /**
+     * 파일 경로에서 언어명을 추출합니다.
+     * 
+     * @param filePath - 언어를 추출할 파일의 절대 경로
+     * @returns 언어명 또는 'Unknown'
+     */
+    extractLanguage(filePath: string): string {
+        const langCode = this.extractLanguageCode(filePath);
+        return LANGUAGE_NAMES[langCode] || langCode.toUpperCase();
+    }
+
+    /**
+     * 파일 경로에서 언어 코드를 추출합니다.
+     * 
+     * @param filePath - 언어 코드를 추출할 파일의 절대 경로
+     * @returns 언어 코드 또는 'unknown'
+     */
+    extractLanguageCode(filePath: string): string {
+        const langMatch = filePath.match(/\/content\/([^/]+)\//); 
+        return langMatch ? langMatch[1] : 'unknown';
+    }
+
+    /**
+     * 원본 파일과 번역 파일의 라인 수를 비교하여 번역 진행률을 계산합니다.
+     * 
+     * @param originalPath - 원본 파일의 절대 경로
+     * @param translationPath - 번역 파일의 절대 경로
+     * @returns 번역 진행률 정보 또는 null
+     */
+    async compareLineCounts(originalPath: string, translationPath: string): Promise<TranslationProgress | null> {
+        try {
+            const filesExist = await this.checkBothFilesExist(originalPath, translationPath);
+            if (!filesExist) {
+                return null;
+            }
+
+            const [originalContent, translationContent] = await this.readBothFiles(originalPath, translationPath);
+            const [originalLines, translationLines] = this.calculateLineCounts(originalContent, translationContent);
+            
+            return this.createProgressResult(originalLines, translationLines);
+        } catch (error) {
+            console.error('Error comparing line counts:', error);
+            return null;
+        }
+    }
+
+    // Private helper methods
+
+    private validateFilePath(filePath: string): boolean {
+        if (!filePath || typeof filePath !== 'string') {
+            console.warn('Invalid file path provided');
+            return false;
+        }
+        return true;
+    }
+
+    private normalizePath(filePath: string): string {
+        return filePath.replace(/\\\\/g, '/');
+    }
+
+    private isKubernetesContentPath(normalizedPath: string): boolean {
+        return normalizedPath.includes('/content/');
+    }
+
+    private isEnglishFile(normalizedPath: string): boolean {
+        return normalizedPath.includes('/content/en/');
+    }
+
+    private async getTranslationPathFromEnglish(normalizedPath: string): Promise<string | null> {
+        const targetLanguage = await this.selectTargetLanguage();
+        if (!targetLanguage) {
+            console.log('User cancelled language selection');
+            return null;
+        }
+        
+        return normalizedPath.replace('/content/en/', `/content/${targetLanguage}/`);
+    }
+
+    private getEnglishPathFromTranslation(normalizedPath: string): string | null {
+        const langMatch = normalizedPath.match(/\/content\/([^/]+)\//); 
+        if (langMatch && langMatch[1] !== 'en') {
+            const detectedLang = langMatch[1];
+            
+            if (!SUPPORTED_LANGUAGES.includes(detectedLang as any)) {
+                console.warn(`Unsupported language code: ${detectedLang}`);
+                return null;
+            }
+            
+            return normalizedPath.replace(`/content/${detectedLang}/`, '/content/en/');
+        }
+        
+        console.warn('Path does not match expected content structure');
+        return null;
+    }
+
+    private async openFilesInSplitView(originalPath: string, translationPath: string): Promise<void> {
+        const originalUri = vscode.Uri.file(originalPath);
+        await vscode.commands.executeCommand('vscode.open', originalUri, { viewColumn: vscode.ViewColumn.One });
+        
+        const translationUri = vscode.Uri.file(translationPath);
+        await vscode.commands.executeCommand('vscode.open', translationUri, { viewColumn: vscode.ViewColumn.Two });
+    }
+
+    private scrollEditorsToTop(): void {
+        setTimeout(() => {
+            const editors = vscode.window.visibleTextEditors;
+            editors.forEach(editor => {
+                const topPosition = new vscode.Position(0, 0);
+                editor.revealRange(new vscode.Range(topPosition, topPosition), vscode.TextEditorRevealType.AtTop);
+            });
+        }, 100);
+    }
+
+    private showSplitViewMessage(): void {
+        i18n.showInformationMessage('messages.splitViewOpened');
+    }
+
+    private async handleSplitViewError(originalPath: string, translationPath: string): Promise<void> {
+        const createFile = await i18n.showWarningMessage(
+            'messages.translationFileNotExists',
+            undefined,
+            i18n.t('common.create'),
+            i18n.t('common.cancel')
+        );
+        
+        if (createFile === i18n.t('common.create')) {
+            await this.createTranslationFile(originalPath, translationPath);
+        }
+    }
+
+    private validateCreateFileParams(originalPath: string, translationPath: string): boolean {
+        if (!originalPath || !translationPath) {
+            i18n.showErrorMessage('messages.invalidFilePath');
+            return false;
+        }
+        return true;
+    }
+
+    private async checkFileCreationPreconditions(originalPath: string, translationPath: string): Promise<boolean> {
+        const originalExists = await this.fileExists(originalPath);
+        if (!originalExists) {
+            i18n.showErrorMessage('messages.originalFileNotFound', { path: originalPath });
+            return false;
+        }
+        
+        const translationExists = await this.fileExists(translationPath);
+        if (translationExists) {
+            return await this.confirmOverwrite(translationPath);
+        }
+        
+        return true;
+    }
+
+    private async fileExists(filePath: string): Promise<boolean> {
+        try {
+            await vscode.workspace.fs.stat(vscode.Uri.file(filePath));
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    private async confirmOverwrite(translationPath: string): Promise<boolean> {
+        const overwrite = await i18n.showWarningMessage(
+            'messages.fileAlreadyExists',
+            { filename: path.basename(translationPath) },
+            i18n.t('common.overwrite'),
+            i18n.t('common.cancel')
+        );
+        
+        return overwrite === i18n.t('common.overwrite');
+    }
+
+    private async createFileAndDirectory(translationPath: string): Promise<void> {
+        const dir = path.dirname(translationPath);
+        await vscode.workspace.fs.createDirectory(vscode.Uri.file(dir));
+        
+        await vscode.workspace.fs.writeFile(
+            vscode.Uri.file(translationPath),
+            Buffer.from('', 'utf8')
+        );
+    }
+
+    private handleFileCreationError(error: unknown): void {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error('createTranslationFile error:', error);
+        i18n.showErrorMessage('messages.fileCopyFailed', { error: errorMessage });
+    }
+
+    private async checkBothFilesExist(originalPath: string, translationPath: string): Promise<boolean> {
+        const originalExists = await this.fileExists(originalPath);
+        const translationExists = await this.fileExists(translationPath);
+        
+        return originalExists && translationExists;
+    }
+
+    private async readBothFiles(originalPath: string, translationPath: string): Promise<[Uint8Array, Uint8Array]> {
         const originalContent = await vscode.workspace.fs.readFile(vscode.Uri.file(originalPath));
         const translationContent = await vscode.workspace.fs.readFile(vscode.Uri.file(translationPath));
         
-        // 라인 수 계산
+        return [originalContent, translationContent];
+    }
+
+    private calculateLineCounts(originalContent: Uint8Array, translationContent: Uint8Array): [number, number] {
         const originalLines = originalContent.toString().split('\n').length;
         const translationLines = translationContent.toString().split('\n').length;
         
+        return [originalLines, translationLines];
+    }
+
+    private createProgressResult(originalLines: number, translationLines: number): TranslationProgress {
         return {
             originalLines,
             translationLines,
             isEqual: originalLines === translationLines,
             percentage: originalLines > 0 ? Math.round((translationLines / originalLines) * 100) : 0
         };
-    } catch (error) {
-        console.error('Error comparing line counts:', error);
-        return null;
     }
+}
+
+// 기존 함수들을 유지 (하위 호환성)
+const translationUtils = new TranslationUtils();
+
+export async function getTranslationPath(filePath: string): Promise<string | null> {
+    return await translationUtils.getTranslationPath(filePath);
+}
+
+export async function selectTargetLanguage(): Promise<string | null> {
+    return await translationUtils.selectTargetLanguage();
+}
+
+export async function openSplitView(originalPath: string, translationPath: string): Promise<void> {
+    return await translationUtils.openSplitView(originalPath, translationPath);
+}
+
+export async function createTranslationFile(originalPath: string, translationPath: string): Promise<void> {
+    return await translationUtils.createTranslationFile(originalPath, translationPath);
+}
+
+export function extractLanguage(filePath: string): string {
+    return translationUtils.extractLanguage(filePath);
+}
+
+export function extractLanguageCode(filePath: string): string {
+    return translationUtils.extractLanguageCode(filePath);
+}
+
+export async function compareLineCounts(originalPath: string, translationPath: string): Promise<TranslationProgress | null> {
+    return await translationUtils.compareLineCounts(originalPath, translationPath);
 }


### PR DESCRIPTION
- Implement internationalization system (en, ko, ja)
- Convert TranslationUtils to class-based architecture
- Centralize language constants and eliminate duplication
- Update toggleSyncScroll shortcut to Ctrl+Shift+Z
 - Add auto-scroll feature for review mode