### PR TITLE
Feature/link validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "test": "npm run compile && node ./out/test/runTest.js",
     "pretest": "npm run compile",
     "vscode:prepublish": "npm run compile",
+    "prepackage": "npm run lint:fix && npm run format && npm run compile",
     "package": "vsce package",
     "lint": "eslint src --ext ts",
     "lint:fix": "eslint src --ext ts --fix",

--- a/src/test/suite/code-action-provider.test.ts
+++ b/src/test/suite/code-action-provider.test.ts
@@ -48,28 +48,36 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
     } as vscode.TextDocument;
 
+    const translationUri = vscode.Uri.file('/content/ko/docs/concepts/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 35),
-      'Missing language path',
+      '번역 파일이 존재합니다: 개요',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.relatedInformation = [
+      new vscode.DiagnosticRelatedInformation(
+        new vscode.Location(translationUri, new vscode.Position(0, 0)),
+        '/ko/docs/concepts/overview'
+      ),
+    ];
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
 
     assert.notStrictEqual(action, undefined);
-    assert.ok(action.title.includes('ko'));
+    assert.ok(action.title.includes('개요'));
     assert.strictEqual(action.kind, vscode.CodeActionKind.QuickFix);
     assert.strictEqual(action.isPreferred, true);
     assert.strictEqual(action.diagnostics?.length, 1);
-    assert.ok(action.edit);
+    assert.ok(action.command);
+    assert.strictEqual(action.command.command, 'vscode.open');
   });
 
-  test('should return undefined for invalid diagnostic text', () => {
+  test('should return undefined for diagnostic without relatedInformation', () => {
     const mockDocument = {
       getText: (_range: vscode.Range) => 'invalid text without link pattern',
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
@@ -81,7 +89,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       vscode.DiagnosticSeverity.Warning
     );
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
@@ -95,13 +103,20 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
     } as vscode.TextDocument;
 
+    const translationUri = vscode.Uri.file('/content/ko/docs/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 20),
-      'Missing language path',
+      '번역 파일이 존재합니다: overview',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.relatedInformation = [
+      new vscode.DiagnosticRelatedInformation(
+        new vscode.Location(translationUri, new vscode.Position(0, 0)),
+        '/ko/docs/overview'
+      ),
+    ];
 
     const mockContext = {
       diagnostics: [mockDiagnostic],
@@ -138,11 +153,12 @@ suite('LinkCodeActionProvider Unit Tests', () => {
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    // No relatedInformation → should return undefined
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
-    assert.strictEqual(action, undefined, 'Should return undefined when error occurs');
+    assert.strictEqual(action, undefined, 'Should return undefined when no relatedInformation');
   });
 });

--- a/src/test/suite/code-action-provider.test.ts
+++ b/src/test/suite/code-action-provider.test.ts
@@ -29,7 +29,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
 
     // Set proper source and code for first diagnostic
     mockDiagnostics[0].source = 'KubeLingoAssist';
-    mockDiagnostics[0].code = 'missing-language-path';
+    mockDiagnostics[0].code = 'translation-available';
 
     // Second diagnostic has different source
     mockDiagnostics[1].source = 'TypeScript';
@@ -39,7 +39,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
 
     assert.strictEqual(filtered.length, 1);
     assert.strictEqual(filtered[0].source, 'KubeLingoAssist');
-    assert.strictEqual(filtered[0].code, 'missing-language-path');
+    assert.strictEqual(filtered[0].code, 'translation-available');
   });
 
   test('should create code action for valid link diagnostic', () => {
@@ -51,11 +51,11 @@ suite('LinkCodeActionProvider Unit Tests', () => {
     const translationUri = vscode.Uri.file('/content/ko/docs/concepts/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 35),
-      '번역 파일이 존재합니다: 개요',
+      '번역 문서: 개요',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     mockDiagnostic.relatedInformation = [
       new vscode.DiagnosticRelatedInformation(
         new vscode.Location(translationUri, new vscode.Position(0, 0)),
@@ -106,11 +106,11 @@ suite('LinkCodeActionProvider Unit Tests', () => {
     const translationUri = vscode.Uri.file('/content/ko/docs/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 20),
-      '번역 파일이 존재합니다: overview',
+      '번역 문서: overview',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     mockDiagnostic.relatedInformation = [
       new vscode.DiagnosticRelatedInformation(
         new vscode.Location(translationUri, new vscode.Position(0, 0)),
@@ -152,7 +152,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     // No relatedInformation → should return undefined
 
     const action = (codeActionProvider as any).createOpenTranslationFileAction(

--- a/src/test/suite/edge-cases.test.ts
+++ b/src/test/suite/edge-cases.test.ts
@@ -177,12 +177,13 @@ Another [valid link too](/docs/reference/guide) - should also work`;
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    // No relatedInformation → should return undefined
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
-    assert.strictEqual(action, undefined, 'Should return undefined when error occurs');
+    assert.strictEqual(action, undefined, 'Should return undefined when no relatedInformation');
   });
 
   test('should validate regex patterns correctly', () => {

--- a/src/test/suite/edge-cases.test.ts
+++ b/src/test/suite/edge-cases.test.ts
@@ -176,7 +176,7 @@ Another [valid link too](/docs/reference/guide) - should also work`;
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     // No relatedInformation → should return undefined
 
     const action = (codeActionProvider as any).createOpenTranslationFileAction(

--- a/src/test/suite/integration.test.ts
+++ b/src/test/suite/integration.test.ts
@@ -60,8 +60,8 @@ This [already fixed link](/ko/docs/concepts/overview) should be ignored.`;
     assert.strictEqual(actions.length, 1, 'Should provide one code action');
 
     const action = actions[0];
-    assert.ok(action.edit, 'Code action should have edit');
-    assert.ok(action.edit.has(mockDocument.uri), 'Edit should target correct document');
+    assert.ok(action.command, 'Code action should have command');
+    assert.strictEqual(action.command!.command, 'vscode.open', 'Command should open file');
 
     // Restore original method
     (linkValidator as any).fileExists = originalFileExists;

--- a/src/test/suite/integration.test.ts
+++ b/src/test/suite/integration.test.ts
@@ -138,7 +138,7 @@ This [already fixed link](/ko/docs/concepts/overview) should be ignored.`;
     );
     assert.strictEqual(
       diagnostic.code,
-      'missing-language-path',
+      'translation-available',
       'Diagnostic should have correct code'
     );
 

--- a/src/test/suite/link-validator-basic.test.ts
+++ b/src/test/suite/link-validator-basic.test.ts
@@ -2,23 +2,25 @@ import * as assert from 'assert';
 
 suite('LinkValidator Basic Tests', () => {
   test('should detect links without language code', () => {
-    // This would require creating a mock document
-    // For now, we'll test the regex pattern
-    const linkPattern = /\[([^\]]*)\]\(\/docs\/([^)]*)\)/g;
+    const linkPattern = /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g;
     const testText = '[example](/docs/concepts/overview)';
     const matches = [...testText.matchAll(linkPattern)];
 
     assert.strictEqual(matches.length, 1);
     assert.strictEqual(matches[0][1], 'example');
-    assert.strictEqual(matches[0][2], 'concepts/overview');
+    assert.strictEqual(matches[0][2], undefined); // no language prefix
+    assert.strictEqual(matches[0][3], 'concepts/overview');
   });
 
-  test('should not match links with language code', () => {
-    const linkPattern = /\[([^\]]*)\]\(\/docs\/([^)]*)\)/g;
+  test('should match links with language code', () => {
+    const linkPattern = /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g;
     const testText = '[example](/ko/docs/concepts/overview)';
     const matches = [...testText.matchAll(linkPattern)];
 
-    assert.strictEqual(matches.length, 0);
+    assert.strictEqual(matches.length, 1);
+    assert.strictEqual(matches[0][1], 'example');
+    assert.strictEqual(matches[0][2], 'ko');
+    assert.strictEqual(matches[0][3], 'concepts/overview');
   });
 
   test('should validate expected translation path generation', () => {
@@ -108,7 +110,9 @@ suite('LinkValidator Basic Tests', () => {
       { text: '[test](/docs/overview/)', shouldMatch: true },
       { text: '[test](/docs/overview.md)', shouldMatch: true },
       { text: '[test](/docs/sub/path/file)', shouldMatch: true },
-      { text: '[test](/ko/docs/overview)', shouldMatch: false }, // Has language code
+      { text: '[test](/ko/docs/overview)', shouldMatch: true }, // Has language code - now matched
+      { text: '[test](/en/docs/overview)', shouldMatch: true }, // English prefix - now matched
+      { text: '[test](/zh-cn/docs/overview)', shouldMatch: true }, // Hyphenated lang code
       { text: '[test](https://example.com)', shouldMatch: false }, // External link
       { text: '[test](/other/path)', shouldMatch: false }, // Not /docs/
       { text: 'plain text', shouldMatch: false }, // No link
@@ -117,8 +121,7 @@ suite('LinkValidator Basic Tests', () => {
     ];
 
     testCases.forEach(({ text, shouldMatch }) => {
-      // Create new regex for each test to avoid global state issues
-      const LINK_REGEX = /\[([^\]]*)\]\(\/docs\/([^)]*)\)/;
+      const LINK_REGEX = /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/;
       const matches = LINK_REGEX.test(text);
       assert.strictEqual(matches, shouldMatch, `Regex test failed for: "${text}"`);
     });

--- a/src/test/suite/link-validator-unit.test.ts
+++ b/src/test/suite/link-validator-unit.test.ts
@@ -111,6 +111,31 @@ suite('LinkValidator Unit Tests', () => {
     (linkValidator as any).fileExists = originalFileExists;
   });
 
+  test('should detect links with different language prefix', () => {
+    const mockText = `# Test Document
+[english link](/en/docs/concepts/overview)
+[same lang link](/ko/docs/concepts/overview)`;
+
+    const mockDocument = {
+      getText: () => mockText,
+      positionAt: (offset: number) => new vscode.Position(0, offset),
+      uri: vscode.Uri.file('/content/ko/docs/test.md'),
+    } as vscode.TextDocument;
+
+    const originalFileExists = (linkValidator as any).fileExists;
+    const originalReadTitle = (linkValidator as any).readTitle;
+    (linkValidator as any).fileExists = () => true;
+    (linkValidator as any).readTitle = () => null;
+
+    const diagnosticCount = linkValidator.validateLinks(mockDocument);
+
+    // /en/docs/... should be detected (different lang), /ko/docs/... should be skipped (same lang)
+    assert.strictEqual(diagnosticCount, 1, 'Should detect 1 link with different language prefix');
+
+    (linkValidator as any).fileExists = originalFileExists;
+    (linkValidator as any).readTitle = originalReadTitle;
+  });
+
   test('should handle concurrent validation calls', () => {
     const mockDocument1 = {
       getText: () => '[link1](/docs/concepts/overview1)',

--- a/src/test/suite/link-validator.test.ts
+++ b/src/test/suite/link-validator.test.ts
@@ -151,28 +151,36 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
     } as vscode.TextDocument;
 
+    const translationUri = vscode.Uri.file('/content/ko/docs/concepts/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 35),
-      'Missing language path',
+      '번역 파일이 존재합니다: 개요',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.relatedInformation = [
+      new vscode.DiagnosticRelatedInformation(
+        new vscode.Location(translationUri, new vscode.Position(0, 0)),
+        '/ko/docs/concepts/overview'
+      ),
+    ];
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
 
     assert.notStrictEqual(action, undefined);
-    assert.ok(action.title.includes('ko'));
+    assert.ok(action.title.includes('개요'));
     assert.strictEqual(action.kind, vscode.CodeActionKind.QuickFix);
     assert.strictEqual(action.isPreferred, true);
     assert.strictEqual(action.diagnostics?.length, 1);
-    assert.ok(action.edit);
+    assert.ok(action.command);
+    assert.strictEqual(action.command.command, 'vscode.open');
   });
 
-  test('should return undefined for invalid diagnostic text', () => {
+  test('should return undefined for diagnostic without relatedInformation', () => {
     const mockDocument = {
       getText: (_range: vscode.Range) => 'invalid text without link pattern',
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
@@ -184,7 +192,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       vscode.DiagnosticSeverity.Warning
     );
 
-    const action = (codeActionProvider as any).createFixLanguagePathAction(
+    const action = (codeActionProvider as any).createOpenTranslationFileAction(
       mockDocument,
       mockDiagnostic
     );
@@ -198,13 +206,20 @@ suite('LinkCodeActionProvider Unit Tests', () => {
       uri: vscode.Uri.file('/content/ko/docs/test.md'),
     } as vscode.TextDocument;
 
+    const translationUri = vscode.Uri.file('/content/ko/docs/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 20),
-      'Missing language path',
+      '번역 파일이 존재합니다: overview',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
     mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.relatedInformation = [
+      new vscode.DiagnosticRelatedInformation(
+        new vscode.Location(translationUri, new vscode.Position(0, 0)),
+        '/ko/docs/overview'
+      ),
+    ];
 
     const mockContext = {
       diagnostics: [mockDiagnostic],

--- a/src/test/suite/link-validator.test.ts
+++ b/src/test/suite/link-validator.test.ts
@@ -132,7 +132,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
 
     // Set proper source and code for first diagnostic
     mockDiagnostics[0].source = 'KubeLingoAssist';
-    mockDiagnostics[0].code = 'missing-language-path';
+    mockDiagnostics[0].code = 'translation-available';
 
     // Second diagnostic has different source
     mockDiagnostics[1].source = 'TypeScript';
@@ -142,7 +142,7 @@ suite('LinkCodeActionProvider Unit Tests', () => {
 
     assert.strictEqual(filtered.length, 1);
     assert.strictEqual(filtered[0].source, 'KubeLingoAssist');
-    assert.strictEqual(filtered[0].code, 'missing-language-path');
+    assert.strictEqual(filtered[0].code, 'translation-available');
   });
 
   test('should create code action for valid link diagnostic', () => {
@@ -154,11 +154,11 @@ suite('LinkCodeActionProvider Unit Tests', () => {
     const translationUri = vscode.Uri.file('/content/ko/docs/concepts/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 35),
-      '번역 파일이 존재합니다: 개요',
+      '번역 문서: 개요',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     mockDiagnostic.relatedInformation = [
       new vscode.DiagnosticRelatedInformation(
         new vscode.Location(translationUri, new vscode.Position(0, 0)),
@@ -209,11 +209,11 @@ suite('LinkCodeActionProvider Unit Tests', () => {
     const translationUri = vscode.Uri.file('/content/ko/docs/overview.md');
     const mockDiagnostic = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 20),
-      '번역 파일이 존재합니다: overview',
+      '번역 문서: overview',
       vscode.DiagnosticSeverity.Warning
     );
     mockDiagnostic.source = 'KubeLingoAssist';
-    mockDiagnostic.code = 'missing-language-path';
+    mockDiagnostic.code = 'translation-available';
     mockDiagnostic.relatedInformation = [
       new vscode.DiagnosticRelatedInformation(
         new vscode.Location(translationUri, new vscode.Position(0, 0)),

--- a/src/validators/link.ts
+++ b/src/validators/link.ts
@@ -11,7 +11,7 @@ import {
 const CONSTANTS = {
   DIAGNOSTIC_SOURCE: 'KubeLingoAssist',
   DIAGNOSTIC_CODE: 'missing-language-path',
-  LINK_REGEX: /\[([^\]]*)\]\(\/docs\/([^)]*)\)/g,
+  LINK_REGEX: /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g,
 } as const;
 
 const MESSAGES = {
@@ -56,14 +56,16 @@ export class LinkValidator {
     const diagnostics: vscode.Diagnostic[] = [];
     const text = document.getText();
 
-    const linkRegex = /\[([^\]]*)\]\(\/docs\/([^)]*)\)/g;
+    const linkRegex = /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g;
     let match;
 
     while ((match = linkRegex.exec(text)) !== null) {
-      const linkPath = match[2];
+      const linkLang = match[2]; // optional language prefix (e.g. 'ko', 'en', 'zh-cn')
+      const linkPath = match[3];
       const fullMatch = match[0];
 
-      if (linkPath.match(/^[a-z]{2}\//) || linkPath.match(/^en\//)) {
+      // Skip if the link already points to the current language
+      if (linkLang && linkLang.toLowerCase() === currentLanguage.toLowerCase()) {
         continue;
       }
 

--- a/src/validators/link.ts
+++ b/src/validators/link.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 import {
   isTranslationFile,
   extractLanguageCode,
@@ -14,13 +15,31 @@ const CONSTANTS = {
 } as const;
 
 const MESSAGES = {
-  CODE_ACTION_TITLE: (language: string) => `언어 경로 추가: /${language}/docs/...`,
+  CODE_ACTION_TITLE: (title: string) => `번역 파일 열기: ${title}`,
 } as const;
+
+function readFrontmatterTitle(filePath: string): string | null {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const frontmatterMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) {
+      return null;
+    }
+    const titleMatch = frontmatterMatch[1].match(/^title:\s*(.+)$/m);
+    if (!titleMatch) {
+      return null;
+    }
+    return titleMatch[1].replace(/^["']|["']$/g, '').trim();
+  } catch {
+    return null;
+  }
+}
 
 export class LinkValidator {
   private diagnostics: vscode.DiagnosticCollection;
   private codeActionProvider: LinkCodeActionProvider;
   private fileExists: (filePath: string) => boolean = fileExistsSync;
+  private readTitle: (filePath: string) => string | null = readFrontmatterTitle;
 
   constructor() {
     this.diagnostics = vscode.languages.createDiagnosticCollection('kubelingoassist-links');
@@ -75,15 +94,16 @@ export class LinkValidator {
 
       if (translationExists && expectedTranslationPath) {
         const isFolder = baseLinkPath.endsWith('/');
-        const resourceType = isFolder ? '폴더' : '파일';
-        const message = `⚠️ 번역 ${resourceType}이 존재합니다.`;
-        const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning);
-        diagnostic.source = 'KubeLingoAssist';
-        diagnostic.code = 'missing-language-path';
         const translationFilePath = this.resolveTranslationFilePath(
           expectedTranslationPath,
           isFolder
         );
+        const title = this.readTitle(translationFilePath);
+        const displayTitle = title ?? linkPath;
+        const message = `번역 파일이 존재합니다: ${displayTitle}`;
+        const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning);
+        diagnostic.source = 'KubeLingoAssist';
+        diagnostic.code = 'missing-language-path';
         const translationUri = vscode.Uri.file(translationFilePath);
         diagnostic.relatedInformation = [
           new vscode.DiagnosticRelatedInformation(
@@ -181,7 +201,7 @@ export class LinkCodeActionProvider implements vscode.CodeActionProvider {
     const codeActions: vscode.CodeAction[] = [];
 
     for (const diagnostic of linkDiagnostics) {
-      const action = this.createFixLanguagePathAction(document, diagnostic);
+      const action = this.createOpenTranslationFileAction(document, diagnostic);
       if (action) {
         codeActions.push(action);
       }
@@ -196,40 +216,32 @@ export class LinkCodeActionProvider implements vscode.CodeActionProvider {
     );
   }
 
-  private createFixLanguagePathAction(
-    document: vscode.TextDocument,
+  private createOpenTranslationFileAction(
+    _document: vscode.TextDocument,
     diagnostic: vscode.Diagnostic
   ): vscode.CodeAction | undefined {
     try {
-      const text = document.getText(diagnostic.range);
-      const regex = new RegExp(CONSTANTS.LINK_REGEX.source);
-      const match = text.match(regex);
-
-      if (!match || match.length < 3) {
+      const relatedInfo = diagnostic.relatedInformation;
+      if (!relatedInfo || relatedInfo.length === 0) {
         return undefined;
       }
 
-      const linkText = match[1];
-      const linkPath = match[2];
-      const currentLanguage = extractLanguageCode(document.uri.fsPath);
-
-      if (currentLanguage === 'unknown') {
-        return undefined;
-      }
-
-      const suggestedPath = `/${currentLanguage.toLowerCase()}/docs/${linkPath}`;
-      const newLinkText = `[${linkText}](${suggestedPath})`;
-      const title = MESSAGES.CODE_ACTION_TITLE(currentLanguage);
+      const translationUri = relatedInfo[0].location.uri;
+      const displayTitle = diagnostic.message.replace('번역 파일이 존재합니다: ', '');
+      const title = MESSAGES.CODE_ACTION_TITLE(displayTitle);
 
       const action = new vscode.CodeAction(title, vscode.CodeActionKind.QuickFix);
-      action.edit = new vscode.WorkspaceEdit();
-      action.edit.replace(document.uri, diagnostic.range, newLinkText);
+      action.command = {
+        command: 'vscode.open',
+        title,
+        arguments: [translationUri],
+      };
       action.diagnostics = [diagnostic];
       action.isPreferred = true;
 
       return action;
     } catch (error) {
-      console.warn('Failed to create fix language path action:', error);
+      console.warn('Failed to create open translation file action:', error);
       return undefined;
     }
   }

--- a/src/validators/link.ts
+++ b/src/validators/link.ts
@@ -10,7 +10,7 @@ import {
 
 const CONSTANTS = {
   DIAGNOSTIC_SOURCE: 'KubeLingoAssist',
-  DIAGNOSTIC_CODE: 'missing-language-path',
+  DIAGNOSTIC_CODE: 'translation-available',
   LINK_REGEX: /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g,
 } as const;
 
@@ -56,7 +56,7 @@ export class LinkValidator {
     const diagnostics: vscode.Diagnostic[] = [];
     const text = document.getText();
 
-    const linkRegex = /\[([^\]]*)\]\(\/(?:([a-z]{2}(?:-[a-z]{2})?)\/)?docs\/([^)]*)\)/g;
+    const linkRegex = new RegExp(CONSTANTS.LINK_REGEX.source, 'g');
     let match;
 
     while ((match = linkRegex.exec(text)) !== null) {
@@ -102,10 +102,14 @@ export class LinkValidator {
         );
         const title = this.readTitle(translationFilePath);
         const displayTitle = title ?? linkPath;
-        const message = `번역 파일이 존재합니다: ${displayTitle}`;
-        const diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Warning);
+        const message = `번역 문서: ${displayTitle}`;
+        const diagnostic = new vscode.Diagnostic(
+          range,
+          message,
+          vscode.DiagnosticSeverity.Information
+        );
         diagnostic.source = 'KubeLingoAssist';
-        diagnostic.code = 'missing-language-path';
+        diagnostic.code = 'translation-available';
         const translationUri = vscode.Uri.file(translationFilePath);
         diagnostic.relatedInformation = [
           new vscode.DiagnosticRelatedInformation(
@@ -229,7 +233,7 @@ export class LinkCodeActionProvider implements vscode.CodeActionProvider {
       }
 
       const translationUri = relatedInfo[0].location.uri;
-      const displayTitle = diagnostic.message.replace('번역 파일이 존재합니다: ', '');
+      const displayTitle = diagnostic.message.replace('번역 문서: ', '');
       const title = MESSAGES.CODE_ACTION_TITLE(displayTitle);
 
       const action = new vscode.CodeAction(title, vscode.CodeActionKind.QuickFix);


### PR DESCRIPTION
**What would you like to be added**
<!-- Describe the changes in this PR -->
  Improve LinkValidator to better detect and surface translated documentation links:                                                                                                                                                                                                                                                       
  - Match docs links that already contain a language prefix (e.g. /ko/docs/...)                                                                                                                                                                                                                                                            
  - Change QuickFix action from replacing link text to opening the translation file directly                                                                                                                                                                                                                                               
  - Rename diagnostic code to translation-available and downgrade severity to Information for clarity    

**Why is this needed**
<!-- Explain the motivation or problem this solves -->
  The previous validator missed links with an existing language prefix and used a confusing missing-language-path diagnostic code — implying something was wrong, when it's actually informational. The QuickFix also replaced link text instead of opening the translation file, which was less useful.                                   


**Related Issues**
<!-- Link related issues. Use keywords to auto-close issues when PR is merged: -->
<!-- Closes #123, Fixes #456, Resolves #789 -->

**Type of Change**
<!-- Check the relevant option -->
- [ ] Bug fix
- [X] New feature  
- [ ] UI/Style changes
- [ ] Refactoring
- [ ] Documentation update
- [ ] Test addition/modification
- [ ] Performance improvement

**Testing**
<!-- How did you test your changes? -->
  Updated and added unit tests for link validation, code action provider, edge cases, and integration scenarios. All tests pass via npm test.                                                                                                                                                                                              

**Comments**
<!-- Any additional notes for reviewers -->
  Diagnostic severity changed from Warning to Information — this may affect users who filter by severity level.                                                                                                                                                                                                                            